### PR TITLE
BPath变量名称出现减号错误情况修复

### DIFF
--- a/UnityProject/Assets/Dependencies/BundleMaster/Editor/BundleMasterEditor/BuildAssetsTools.cs
+++ b/UnityProject/Assets/Dependencies/BundleMaster/Editor/BundleMasterEditor/BuildAssetsTools.cs
@@ -194,6 +194,7 @@ namespace BM
                     string name = assetPath.Replace("/", "_");
                     name = name.Replace(".", "__");
                     name = name.Replace("-", "_");
+                    name = name.Replace("+", "_");
                     name = name.Replace(" ", "__");
                     name = RemoveSymbol(name);
                     sb.Append("\t\tpublic const string " + name + " = \"" + assetPath + "\";\n");

--- a/UnityProject/Assets/Dependencies/BundleMaster/Editor/BundleMasterEditor/BuildAssetsTools.cs
+++ b/UnityProject/Assets/Dependencies/BundleMaster/Editor/BundleMasterEditor/BuildAssetsTools.cs
@@ -193,6 +193,7 @@ namespace BM
                 {
                     string name = assetPath.Replace("/", "_");
                     name = name.Replace(".", "__");
+                    name = name.Replace("-", "_");
                     name = name.Replace(" ", "__");
                     name = RemoveSymbol(name);
                     sb.Append("\t\tpublic const string " + name + " = \"" + assetPath + "\";\n");


### PR DESCRIPTION
# BPath变量名称出现减号错误情况

## Bug描述：

若动态资源路径或者文件名称包含了减号 "-"，则会出现 BPath.cs生成的变量名称不符合C#规范。


## Bug原因：

在Assets\Dependencies\BundleMaster\Editor\BundleMasterEditor\BuildAssetsTools.cs文件中的GeneratePathCode里，没有考虑到文件名称包含 "-"这种情况， 若出现这种字符，就会导致HotUpdateScripts\BPath.cs文件里的BPath类的成员变量名称不符合C#命名规则。


## Bug修复：

在Assets\Dependencies\BundleMaster\Editor\BundleMasterEditor\BuildAssetsTools.cs文件里的GeneratePathCode函数中，foreach中，增加一行 name = name.Replace("-", "_"); 即可

如下

```c#
foreach (string assetPath in allAssetPaths)
 {
                    string name = assetPath.Replace("/", "_");
                    name = name.Replace(".", "__");
                    name = name.Replace("-", "_");
                    name = name.Replace(" ", "__");
                    name = RemoveSymbol(name);
                    sb.Append("\t\tpublic const string " + name + " = \"" + assetPath + "\";\n");
}
```