### PR TITLE
Add CLAUDE.md and GitHub Copilot custom instructions

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -1,0 +1,51 @@
+---
+applyTo: "**"
+---
+
+# Code Review Instructions for JEngine
+
+## Priority Checks
+
+### 1. Unity Editor Domain Reload
+Editor code with static state MUST handle domain reloads:
+- Static fields reset to default on recompile
+- Use `SessionState` for session-persistent data
+- Use `EditorPrefs` for cross-session data
+
+### 2. Resource Management
+Check for proper cleanup:
+- ScriptableObjects created with `CreateInstance` must be destroyed
+- Event handlers must be unsubscribed
+- Use `Object.Destroy` (not `DestroyImmediate`) for most cases
+
+### 3. Async Patterns
+Verify async code uses:
+- `UniTask` (not `System.Threading.Tasks.Task`)
+- Proper `await` usage
+- No blocking calls (`Result`, `Wait()`)
+
+### 4. Thread Safety
+For state accessed across Unity callbacks:
+- Use `volatile` for simple flags
+- Consider thread-safe patterns for complex state
+
+### 5. Namespace Compliance
+- Runtime: `JEngine.Core.*`
+- Editor: `JEngine.Core.Editor.*`
+- No namespace = flag for review
+
+## Common Issues to Flag
+
+- Missing XML documentation on public APIs
+- Direct `Debug.Log` (should use proper logging)
+- `Task` instead of `UniTask`
+- Static state in Editor without domain reload handling
+- Missing null checks for Unity objects
+- `DestroyImmediate` without clear justification
+
+## Suggestions Format
+
+When suggesting code changes:
+1. Explain the issue clearly
+2. Provide complete code suggestion
+3. Reference Unity/JEngine conventions

--- a/.github/instructions/jengine.instructions.md
+++ b/.github/instructions/jengine.instructions.md
@@ -1,0 +1,110 @@
+---
+applyTo: "**/*.cs"
+---
+
+# JEngine C# Coding Instructions
+
+## Project Context
+
+JEngine is a Unity hot update framework using HybridCLR for runtime C# execution and YooAsset for resource management.
+
+## Code Style
+
+### Namespaces
+- Runtime code: `JEngine.Core` or `JEngine.Core.*`
+- Editor code: `JEngine.Core.Editor` or `JEngine.Core.Editor.*`
+- Hot update code: `HotUpdate.Code`
+
+### Async/Await
+Always use `UniTask` instead of `Task`:
+```csharp
+// Good
+public async UniTask DoSomethingAsync() { }
+
+// Bad
+public async Task DoSomethingAsync() { }
+```
+
+### XML Documentation
+Document all public members:
+```csharp
+/// <summary>
+/// Description of what this does.
+/// </summary>
+public void MyMethod() { }
+```
+
+## Editor Scripts
+
+### Domain Reload Handling
+Unity reloads the domain on recompile. Static state resets. For persistent state:
+```csharp
+// Use SessionState for editor session persistence
+SessionState.SetBool("MyKey", value);
+bool value = SessionState.GetBool("MyKey", defaultValue);
+```
+
+### Resource Cleanup
+Always clean up ScriptableObjects and event handlers:
+```csharp
+static MyClass()
+{
+    EditorApplication.quitting += OnQuitting;
+}
+
+private static void OnQuitting()
+{
+    EditorApplication.quitting -= OnQuitting;
+    if (_instance != null)
+    {
+        Object.Destroy(_instance);
+        _instance = null;
+    }
+}
+```
+
+### Thread Safety
+For properties accessed from callbacks:
+```csharp
+private static volatile bool _flag;
+public static bool Flag => _flag;
+```
+
+## Encryption Code
+
+Three algorithms supported: XOR, AES, ChaCha20
+- Config classes in `Runtime/Encrypt/Config/`
+- Bundle encryption in `Runtime/Encrypt/Bundle/`
+- Manifest encryption in `Runtime/Encrypt/Manifest/`
+
+## Common Patterns
+
+### ScriptableObject Singletons
+```csharp
+public class MyConfig : ScriptableObject
+{
+    private static MyConfig _instance;
+    public static MyConfig Instance => _instance ??= CreateInstance<MyConfig>();
+}
+```
+
+### InitializeOnLoad
+```csharp
+[InitializeOnLoad]
+internal class MyEditorClass
+{
+    static MyEditorClass()
+    {
+        // Runs on editor load and domain reload
+    }
+}
+```
+
+## Review Focus Areas
+
+When reviewing JEngine code, check:
+1. UniTask usage (not Task)
+2. Domain reload handling in Editor code
+3. Resource cleanup (ScriptableObjects, events)
+4. Thread safety for callback-accessed state
+5. Proper namespace usage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,171 @@
+# JEngine Development Guidelines
+
+## Project Overview
+
+JEngine is a Unity framework for **runtime hot updates** in games. It enables developers to update game code and assets without requiring users to download new builds.
+
+- **Unity Version**: 2022.3+
+- **Primary Language**: C#
+- **License**: MIT
+
+## Architecture
+
+### Package Structure
+
+```
+Packages/
+├── com.jasonxudeveloper.jengine.core/   # Main framework
+│   ├── Runtime/                         # Runtime code
+│   │   ├── Bootstrap.cs                 # Main entry point
+│   │   ├── Encrypt/                     # Encryption subsystem
+│   │   └── Update/                      # Update management
+│   └── Editor/                          # Editor tools
+└── com.code-philosophy.hybridclr/       # HybridCLR integration
+
+Assets/
+├── HotUpdate/                           # Hot-updateable code
+│   └── Code/EntryPoint.cs               # Hot update entry point
+└── Samples/                             # Sample implementations
+```
+
+### Key Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| HybridCLR | Runtime C# code execution |
+| YooAsset | Runtime resource management |
+| UniTask | Async/await support |
+| Nino | High-performance serialization |
+| Obfuz | Code obfuscation |
+
+## Coding Conventions
+
+### Namespaces
+
+- Core framework: `JEngine.Core.*`
+- Editor code: `JEngine.Core.Editor.*`
+- Hot update code: `HotUpdate.Code`
+
+### File Headers
+
+All C# files should include the standard header:
+```csharp
+// FileName.cs
+//
+//  Author:
+//        JasonXuDeveloper <jason@xgamedev.net>
+//
+//  Copyright (c) 2025 JEngine
+//
+//  [MIT License...]
+```
+
+### Naming Conventions
+
+- **Classes/Interfaces**: PascalCase (interfaces prefixed with `I`)
+- **Methods/Properties**: PascalCase
+- **Private fields**: camelCase or `_camelCase`
+- **Constants**: PascalCase
+- **Enums**: PascalCase for both type and members
+
+### Async Patterns
+
+Use `UniTask` for async operations, not `System.Threading.Tasks.Task`:
+```csharp
+public async UniTask<bool> LoadAssetAsync() { }
+```
+
+### XML Documentation
+
+Document all public APIs with XML comments:
+```csharp
+/// <summary>
+/// Brief description of the method.
+/// </summary>
+/// <param name="param">Parameter description.</param>
+/// <returns>Return value description.</returns>
+public ReturnType MethodName(ParamType param) { }
+```
+
+## Important Patterns
+
+### Encryption Architecture
+
+JEngine supports three encryption algorithms:
+- **XOR** (`EncryptionOption.Xor`) - Fast, simple
+- **AES** (`EncryptionOption.Aes`) - Moderate security
+- **ChaCha20** (`EncryptionOption.ChaCha20`) - High security
+
+Each has implementations for bundles and manifests in `Runtime/Encrypt/`.
+
+### ScriptableObject Configuration
+
+Use `ScriptableObject` for runtime configuration:
+```csharp
+public abstract class ConfigBase<T> : ScriptableObject where T : ConfigBase<T>
+{
+    public static T Instance { get; }
+}
+```
+
+### Editor Scripts
+
+- Use `[InitializeOnLoad]` for editor initialization
+- Handle Unity domain reloads properly (state resets on recompile)
+- Use `SessionState` or `EditorPrefs` for persistent editor state
+- Clean up resources in `EditorApplication.quitting`
+
+### Thread Safety
+
+For properties accessed across callbacks:
+```csharp
+private static volatile bool _flag;
+public static bool Flag => _flag;
+```
+
+## Testing
+
+- Tests are in `Assets/Tests/` using Unity Test Framework
+- Run tests via Unity Test Runner (Window > General > Test Runner)
+- Editor code should check `TestRunnerCallbacks.IsRunningTests` to avoid interfering with test execution
+
+## Build & Deployment
+
+### Target Platforms
+
+- `Standalone` - Desktop builds
+- `WeChat` / `Douyin` / `Alipay` / `TapTap` - Mini-game platforms
+
+### Hot Update Workflow
+
+1. Build base application with HybridCLR
+2. Update code in `Assets/HotUpdate/`
+3. Build hot update DLLs
+4. Deploy to CDN server
+
+## Common Tasks
+
+### Adding New Encryption
+
+1. Create config class in `Runtime/Encrypt/Config/`
+2. Implement bundle encryption in `Runtime/Encrypt/Bundle/`
+3. Implement manifest encryption in `Runtime/Encrypt/Manifest/`
+4. Add to `EncryptionOption` enum
+5. Update `EncryptionMapping` class
+
+### Adding Editor Features
+
+1. Create class in `Editor/` with appropriate namespace
+2. Use `[InitializeOnLoad]` for auto-initialization
+3. Add menu items via `[MenuItem]` attribute
+4. Handle domain reloads if maintaining state
+
+## Code Review Checklist
+
+- [ ] Follows namespace conventions
+- [ ] Has appropriate XML documentation
+- [ ] Uses UniTask for async (not Task)
+- [ ] Handles Unity domain reloads in Editor code
+- [ ] No direct `Debug.Log` in production code (use proper logging)
+- [ ] Thread-safe where needed (Editor callbacks, etc.)
+- [ ] Proper resource cleanup (ScriptableObjects, event handlers)


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with JEngine-specific development guidelines for AI assistants
- Add `.github/instructions/jengine.instructions.md` for C# code style guidance
- Add `.github/instructions/code-review.instructions.md` for PR review guidance

## Details

These files help AI assistants (Claude Code, GitHub Copilot) understand JEngine's:

**Architecture**
- Package structure and namespaces
- Key dependencies (HybridCLR, YooAsset, UniTask, Nino)
- Encryption subsystem design

**Coding Conventions**
- UniTask for async (not Task)
- XML documentation requirements
- Naming conventions

**Critical Patterns**
- Unity Editor domain reload handling
- Resource cleanup (ScriptableObjects, events)
- Thread safety for callback-accessed state
- SessionState/EditorPrefs for persistent editor data

## Test plan
- [x] Verify CLAUDE.md renders correctly on GitHub
- [x] Verify Copilot instructions are in correct format

🤖 Generated with [Claude Code](https://claude.com/claude-code)