### PR TITLE
fix-testrunner-assembly-references

### DIFF
--- a/UnityProject/Packages/com.jasonxudeveloper.jengine.core/Editor/JEngine.Core.Editor.asmdef
+++ b/UnityProject/Packages/com.jasonxudeveloper.jengine.core/Editor/JEngine.Core.Editor.asmdef
@@ -11,7 +11,9 @@
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
         "GUID:e34a5702dd353724aa315fb8011f08c3",
         "GUID:3743e71edcd5bd8499007797ef02cbfb",
-        "GUID:27619889b8ba8c24980f49ee34dbb44a"
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "UnityEditor.TestRunner",
+        "UnityEngine.TestRunner"
     ],
     "includePlatforms": [
         "Editor"


### PR DESCRIPTION
Add missing Unity Test Framework assembly references to `JEngine.Core.Editor.asmdef` to fix compilation errors in `TestRunnerCallbacks.cs`. The file uses types from `UnityEditor.TestTools.TestRunner.Api` namespace (e.g., `ICallbacks`, `TestRunnerApi`, `ITestAdaptor`, `ITestResultAdaptor`) which require explicit assembly references.