### PR TITLE
chore(util): reset package version to 0.0.0

### DIFF
--- a/UnityProject/Packages/com.jasonxudeveloper.jengine.util/package.json
+++ b/UnityProject/Packages/com.jasonxudeveloper.jengine.util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jasonxudeveloper.jengine.util",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "displayName": "JEngine.Util",
   "description": "Utility classes for JEngine framework.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Reset JEngine.Util package version from 1.0.0 to 0.0.0
- This package hasn't been released yet, so version should start at 0.0.0

## Test plan
- [x] Verify package.json shows version 0.0.0
- [x] Confirm package still loads correctly in Unity

🤖 Generated with [Claude Code](https://claude.com/claude-code)