### PR TITLE
fix(ci): correct test artifact paths in unity-tests workflow

### DIFF
--- a/.github/workflows/unity-tests.yml
+++ b/.github/workflows/unity-tests.yml
@@ -60,6 +60,7 @@ jobs:
           projectPath: ${{ inputs.project_path }}
           unityVersion: ${{ inputs.unity_version }}
           testMode: EditMode
+          artifactsPath: artifacts/EditMode
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: EditMode Test Results
 
@@ -76,6 +77,7 @@ jobs:
           projectPath: ${{ inputs.project_path }}
           unityVersion: ${{ inputs.unity_version }}
           testMode: PlayMode
+          artifactsPath: artifacts/PlayMode
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           checkName: PlayMode Test Results
 
@@ -85,7 +87,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: EditMode-results-${{ inputs.unity_version }}
-          path: ${{ inputs.project_path }}/artifacts/EditMode
+          path: artifacts/EditMode
+          if-no-files-found: warn
           retention-days: 14
 
       - name: Upload PlayMode test results
@@ -93,7 +96,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: PlayMode-results-${{ inputs.unity_version }}
-          path: ${{ inputs.project_path }}/artifacts/PlayMode
+          path: artifacts/PlayMode
+          if-no-files-found: warn
           retention-days: 14
 
       # Generate test summary


### PR DESCRIPTION
## Summary
- Fix test artifact paths that were causing "No files found" warnings
- Explicitly set `artifactsPath` for game-ci/unity-test-runner
- Add `if-no-files-found: warn` to gracefully handle missing artifacts

## Problem
The workflow was looking for artifacts at:
- `UnityProject/artifacts/PlayMode`
- `UnityProject/artifacts/EditMode`

But game-ci/unity-test-runner outputs to the repo root by default, not inside the project directory.

## Solution
- Explicitly set `artifactsPath: artifacts/EditMode` and `artifactsPath: artifacts/PlayMode` in the test runner steps
- Update upload paths to match: `artifacts/EditMode` and `artifacts/PlayMode`
- Add `if-no-files-found: warn` so missing artifacts show a warning instead of failing

## Test plan
- [ ] Run the release workflow again after merging
- [ ] Verify artifacts are uploaded correctly
- [ ] Check that test results appear in the workflow summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)