### PR TITLE
fix(ci): fix release workflow regex parsing error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,11 +177,14 @@ jobs:
           OTHER=""
           CONTRIBUTORS=""
 
+          # Store regex in variable to avoid bash parsing issues with special characters
+          COMMIT_PATTERN='^([a-z]+)(\(([^)]+)\))?!?:[[:space:]](.+)$'
+
           while IFS='|' read -r hash subject author; do
             [ -z "$hash" ] && continue
 
             # Extract commit type and scope
-            if [[ $subject =~ ^([a-z]+)(\(([^)]+)\))?!?:\ (.+)$ ]]; then
+            if [[ $subject =~ $COMMIT_PATTERN ]]; then
               type="${BASH_REMATCH[1]}"
               scope="${BASH_REMATCH[3]}"
               description="${BASH_REMATCH[4]}"


### PR DESCRIPTION
## Summary
- Fix bash syntax error in release workflow changelog generation
- Store regex pattern in variable to avoid parsing issues

## Problem
The release workflow was failing with:
```
syntax error in conditional expression: unexpected token `)'
```

The regex pattern `^([a-z]+)(\(([^)]+)\))?!?:\ (.+)$` contains parentheses and brackets that bash was misinterpreting during script expansion.

## Solution
Store the regex pattern in a variable first:
```bash
COMMIT_PATTERN='^([a-z]+)(\(([^)]+)\))?!?:[[:space:]](.+)$'
if [[ $subject =~ $COMMIT_PATTERN ]]; then
```

This prevents bash from parsing the special characters during expansion.

## Test plan
- [ ] Run the release workflow again after merging
- [ ] Verify changelog generation works correctly
- [ ] Check that conventional commits are properly parsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)