### PR TITLE
fix(ci): use pipe delimiter in sed to avoid URL slash conflict

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,8 +196,8 @@ jobs:
             if [[ $subject =~ $PR_PATTERN ]]; then
               pr_num="${BASH_REMATCH[1]}"
               pr_link="[#${pr_num}](https://github.com/${REPO}/pull/${pr_num})"
-              # Replace (#123) with the hyperlink
-              subject=$(echo "$subject" | sed "s/(#${pr_num})/(${pr_link})/")
+              # Replace (#123) with the hyperlink (use | as delimiter to avoid conflict with URL slashes)
+              subject=$(echo "$subject" | sed "s|(#${pr_num})|(${pr_link})|")
 
               # Get contributor from PR using GitHub API
               pr_author=$(gh api "repos/${REPO}/pulls/${pr_num}" --jq '.user.login' 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary
Fixes a bug in PR #568 where the sed command breaks because URLs contain `/` which is the default sed delimiter.

**Before (broken):**
```bash
sed "s/(#566)/([#566](https://github.com/.../pull/566))/"
#                              ^ these slashes break sed
```

**After (fixed):**
```bash
sed "s|(#566)|([#566](https://github.com/.../pull/566))|"
#    ^ using pipe as delimiter instead
```

## Test plan
- [ ] Merge this PR
- [ ] Run release workflow with `core_version=1.0.7` and `util_version=1.0.1`
- [ ] Verify PR hyperlinks are properly formatted in changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)