### PR TITLE
ci: support conditional required checks with path filtering

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,29 +3,47 @@ name: CodeQL Security Analysis
 on:
   push:
     branches: [master]
-    paths:
-      # Only run when JEngine code changes
-      - 'UnityProject/Packages/com.jasonxudeveloper.jengine.core/**'
-      - 'UnityProject/Packages/com.jasonxudeveloper.jengine.util/**'
-      - 'UnityProject/Assets/HotUpdate/Code/**'
-      - '.github/codeql/**'
-      - '.github/workflows/codeql.yml'
+    # Path filtering moved to job level for push events
   pull_request:
     branches: [master]
-    paths:
-      - 'UnityProject/Packages/com.jasonxudeveloper.jengine.core/**'
-      - 'UnityProject/Packages/com.jasonxudeveloper.jengine.util/**'
-      - 'UnityProject/Assets/HotUpdate/Code/**'
-      - '.github/codeql/**'
-      - '.github/workflows/codeql.yml'
+    # Path filtering moved to job level using dorny/paths-filter
+    # This ensures the workflow always runs and reports a status
   schedule:
     # Run weekly on Sunday at 00:00 UTC
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    # Only run path detection for push/pull_request events
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    outputs:
+      should_analyze: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'UnityProject/Packages/com.jasonxudeveloper.jengine.core/**'
+              - 'UnityProject/Packages/com.jasonxudeveloper.jengine.util/**'
+              - 'UnityProject/Assets/HotUpdate/Code/**'
+              - '.github/codeql/**'
+              - '.github/workflows/codeql.yml'
+
   analyze:
     name: Analyze C# Code
+    needs: changes
+    # Run if: 1) changes detected, 2) schedule event, or 3) manual dispatch
+    if: |
+      always() && (
+        needs.changes.outputs.should_analyze == 'true' ||
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch'
+      )
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -50,3 +68,16 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:csharp"
+
+  skip-analyze:
+    name: Analyze C# Code
+    needs: changes
+    # Only skip for push/pull_request when no relevant changes
+    if: |
+      always() &&
+      (github.event_name == 'push' || github.event_name == 'pull_request') &&
+      needs.changes.outputs.should_analyze == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip analysis
+        run: echo "No relevant changes detected, skipping CodeQL analysis"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -2,12 +2,10 @@ name: PR Tests
 
 on:
   pull_request:
+    branches: [master]
     types: [opened, synchronize, reopened]
-    paths:
-      - 'UnityProject/Packages/com.jasonxudeveloper.jengine.core/**'
-      - 'UnityProject/Packages/com.jasonxudeveloper.jengine.util/**'
-      - 'UnityProject/Assets/Tests/**'
-      - '.github/workflows/**'
+    # Path filtering moved to job level using dorny/paths-filter
+    # This ensures the workflow always runs and reports a status
 
 # Ensure only one test run per PR at a time
 concurrency:
@@ -20,19 +18,47 @@ permissions:
   statuses: write
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      should_test: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'UnityProject/Packages/com.jasonxudeveloper.jengine.core/**'
+              - 'UnityProject/Packages/com.jasonxudeveloper.jengine.util/**'
+              - 'UnityProject/Assets/Tests/**'
+              - '.github/workflows/**'
+
   run-tests:
     name: Run Unity Tests
+    needs: changes
+    if: needs.changes.outputs.should_test == 'true'
     permissions:
       contents: read
       checks: write
     uses: ./.github/workflows/unity-tests.yml
     secrets: inherit
 
+  skip-tests:
+    name: Run Unity Tests
+    needs: changes
+    if: needs.changes.outputs.should_test == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip tests
+        run: echo "No relevant changes detected, skipping tests"
+
   comment-results:
     name: Comment Test Results
-    needs: run-tests
+    needs: [changes, run-tests, skip-tests]
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && needs.changes.outputs.should_test == 'true'
     permissions:
       pull-requests: write
       statuses: write


### PR DESCRIPTION
## Summary

- Fix "Waiting for status to be reported" issue when PR doesn't match path filters
- Use `dorny/paths-filter@v3` to detect file changes at job level instead of workflow level
- Skip jobs report success with matching names so GitHub Ruleset correctly identifies check status

## Problem

GitHub Ruleset requires `Run Unity Tests` and `Analyze C# Code` checks to pass before merge. However, these workflows have path filters that prevent them from running when only documentation files change. This causes PRs to show "Waiting for status to be reported" indefinitely.

## Solution

Move path filtering from workflow level to job level:

1. **Detect Changes Job**: Uses `dorny/paths-filter` to check if relevant files changed
2. **Actual Job**: Runs only when changes are detected
3. **Skip Job**: Runs when no changes detected, uses same `name` as actual job

Since both jobs share the same `name`, GitHub sees them as the same check and the Ruleset requirement is satisfied.

## Changes

| File | Changes |
|------|---------|
| `pr-tests.yml` | Add `changes` job, `skip-tests` job with same name as `run-tests` |
| `codeql.yml` | Add `changes` job, `skip-analyze` job with same name as `analyze`; schedule/dispatch always run |

## Test Plan

- [ ] Create PR with only documentation changes → `skip-*` jobs run, checks pass immediately
- [ ] Create PR with code changes → actual test/analysis jobs run as before
- [ ] Scheduled CodeQL analysis continues to run weekly

🤖 Generated with [Claude Code](https://claude.com/claude-code)