### PR TITLE
fix(ci): fix auto-approve to check claude[bot] comment

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -50,17 +50,16 @@ jobs:
           HEAD_SHA=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER --jq '.head.sha')
           echo "Head SHA: $HEAD_SHA"
 
-          # Check Claude review status and output
-          CLAUDE_CHECK=$(gh api repos/${{ github.repository }}/commits/$HEAD_SHA/check-runs --jq '.check_runs[] | select(.name == "claude-review")')
-          CLAUDE_STATUS=$(echo "$CLAUDE_CHECK" | jq -r '.conclusion' | head -1)
-          CLAUDE_OUTPUT=$(echo "$CLAUDE_CHECK" | jq -r '.output.summary // .output.text // ""' | head -1)
-          echo "Claude review status: $CLAUDE_STATUS"
-          echo "Claude review output: $CLAUDE_OUTPUT"
+          # Check Claude review - look for "No issues found" comment from claude[bot]
+          # Claude posts a PR comment with this message when review passes
+          CLAUDE_COMMENTS=$(gh api "repos/${{ github.repository }}/issues/$PR_NUMBER/comments" --jq '[.[] | select(.user.login == "claude[bot]") | .body] | join("\n")')
 
-          # Check if Claude found no issues (exact message check)
           CLAUDE_APPROVED="false"
-          if [ "$CLAUDE_STATUS" == "success" ] && echo "$CLAUDE_OUTPUT" | grep -q "No issues found. Checked for bugs and CLAUDE.md compliance"; then
+          if echo "$CLAUDE_COMMENTS" | grep -q "No issues found. Checked for bugs and CLAUDE.md compliance"; then
+            echo "Claude review: No issues found"
             CLAUDE_APPROVED="true"
+          else
+            echo "Claude review: Issues found or not yet complete"
           fi
           echo "Claude approved: $CLAUDE_APPROVED"
 

--- a/.scorecard.yml
+++ b/.scorecard.yml
@@ -47,3 +47,13 @@ annotations:
       - token-permissions
     reasons:
       - reason: not-applicable # Write permissions required for test reporting and release automation
+
+  # Branch protection: Using GitHub Rulesets with auto-approve bot
+  # - Rulesets require 1 approver (provided by auto-approve bot)
+  # - Code owner review is required
+  # - last_push_approval disabled to allow auto-approve bot to work
+  # - bypass_actors: [] prevents admin bypass
+  - checks:
+      - branch-protection
+    reasons:
+      - reason: not-applicable # Using Rulesets with auto-approve bot requiring last_push_approval disabled


### PR DESCRIPTION
## Summary
- Fix auto-approve workflow to check for `claude[bot]` PR comment containing "No issues found. Checked for bugs and CLAUDE.md compliance."
- Add branch-protection annotation to scorecard config explaining why `last_push_approval` is disabled

## Changes
1. **auto-approve.yml**: Check PR comments from `claude[bot]` instead of check run output fields (which are not set by Claude Code Action)
2. **.scorecard.yml**: Add annotation explaining branch-protection settings

## Test plan
- [ ] Auto-approve triggers when Claude review posts "No issues found" comment
- [ ] PR gets approved automatically when both Claude review and Unity Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)