### PR TITLE
fix(ci): add pull-requests write permission for Claude review comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: read
 
 jobs:
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary
Add `pull-requests: write` permission to Claude Code Review workflow so it can post review comments on PRs.

## Problem
Claude Code Action needs write permission to post comments. Without this, the action runs but cannot post the "No issues found" or issue comments, breaking the auto-approve workflow.

## Note
This PR requires **manual approval** since the Claude workflow validation will fail (workflow file differs from master). Once merged, future PRs will get Claude review comments and auto-approve will work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)