### PR TITLE
fix(core): resolve SceneHandle ambiguous reference in Unity 6

### DIFF
--- a/UnityProject/Packages/com.jasonxudeveloper.jengine.core/Runtime/Bootstrap.Common.cs
+++ b/UnityProject/Packages/com.jasonxudeveloper.jengine.core/Runtime/Bootstrap.Common.cs
@@ -29,6 +29,7 @@ using JEngine.Core.Encrypt;
 using JEngine.Core.Update;
 using UnityEngine.SceneManagement;
 using YooAsset;
+using SceneHandle = YooAsset.SceneHandle;
 
 namespace JEngine.Core
 {


### PR DESCRIPTION
## Summary

- Fixes CS0104 ambiguous reference error between `YooAsset.SceneHandle` and `UnityEngine.SceneManagement.SceneHandle` in Unity 6 (6000.x)
- Adds a using alias to explicitly specify `YooAsset.SceneHandle` in `Bootstrap.Common.cs`

## Root Cause

Unity 6 introduced `UnityEngine.SceneManagement.SceneHandle`, which conflicts with `YooAsset.SceneHandle` when both namespaces are imported.

## Solution

Added using alias at the top of the file:
```csharp
using SceneHandle = YooAsset.SceneHandle;
```

This keeps the code clean and makes the intent explicit.

Fixes #587

## Test plan

- [ ] Verify compilation succeeds in Unity 6000.x
- [ ] Verify existing behavior is preserved (no logic changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)