### PR TITLE
fix(core): convert AsyncOperation to UniTask for Unity 6 compatibility

### DIFF
--- a/UnityProject/Packages/com.jasonxudeveloper.jengine.core/Runtime/Bootstrap.Common.cs
+++ b/UnityProject/Packages/com.jasonxudeveloper.jengine.core/Runtime/Bootstrap.Common.cs
@@ -92,7 +92,7 @@ namespace JEngine.Core
                 // Call error callback
                 await callbacks.OnError(e);
                 // Switch back to previous scene
-                await SceneManager.LoadSceneAsync(previousSceneName);
+                await SceneManager.LoadSceneAsync(previousSceneName).ToUniTask();
 
                 return null;
             }


### PR DESCRIPTION
## Summary
- Fix CS0311 compilation error in Unity 6 where `UnityEngine.AsyncOperation` cannot be directly awaited
- Convert `SceneManager.LoadSceneAsync()` to use `.ToUniTask()` extension method

## Problem
In Unity 6, `UnityEngine.AsyncOperation` cannot be used as a type parameter for `EnumeratorAsyncExtensions.GetAwaiter<T>()` because there's no implicit reference conversion to `System.Collections.IEnumerator`.

## Solution
Use the `ToUniTask()` extension method from `Cysharp.Threading.Tasks` to convert the `AsyncOperation` to a `UniTask`, which can be awaited. This pattern is already used elsewhere in the codebase (e.g., line 145 in the same file).

## Test plan
- [ ] Open the project in Unity 6
- [ ] Verify no CS0311 compilation errors
- [ ] Test scene loading error path to ensure fallback scene loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)