### PR TITLE
fix(plugin): correct skills paths to include .claude-plugin prefix

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -20,9 +20,9 @@
     "gc-optimization"
   ],
   "skills": [
-    "./skills/jaction",
-    "./skills/jobjectpool",
-    "./skills/messagebox",
-    "./skills/editor-ui"
+    "./.claude-plugin/skills/jaction",
+    "./.claude-plugin/skills/jobjectpool",
+    "./.claude-plugin/skills/messagebox",
+    "./.claude-plugin/skills/editor-ui"
   ]
 }


### PR DESCRIPTION
## Summary

Fix skills paths in plugin.json - they need to be relative to repo root, not to the plugin.json location.

## Issue

Skills were not loading because paths like `./skills/jaction` resolved to repo root, but skills are inside `.claude-plugin/skills/`.

## Fix

Changed paths from:
- `./skills/jaction` → `./.claude-plugin/skills/jaction`

🤖 Generated with [Claude Code](https://claude.com/claude-code)