### PR TITLE
fix(ci): resolve Codecov path mismatch causing unusable reports

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,12 @@ coverage:
         target: auto
         threshold: 1%
 
+# Fix Docker container path prefix in coverage reports
+# Unity test runner generates paths like /github/workspace/UnityProject/...
+# This strips the /github/workspace/ prefix to match repository structure
+fixes:
+  - "/github/workspace/::"
+
 # Flag management for per-package coverage tracking
 flag_management:
   default_rules:


### PR DESCRIPTION
## Summary

- Add `fixes` section to `codecov.yml` that strips the Docker container path prefix (`/github/workspace/`) from coverage reports
- Unity test runner generates paths like `/github/workspace/UnityProject/...` inside the Docker container
- Codecov expects paths relative to repo root: `UnityProject/...`
- The path mismatch was causing reports to be marked as "unusable"

## Test plan

- [ ] Wait for PR tests to run (note: this config-only change won't trigger Unity tests due to path filters)
- [ ] Merge this PR and verify coverage uploads succeed on subsequent PRs that modify package code
- [ ] Check Codecov dashboard shows actual coverage percentages instead of "unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)