### PR TITLE
fix(util): use using statement for JAction in Reset_AllowsReuse test

### DIFF
--- a/UnityProject/Packages/com.jasonxudeveloper.jengine.util/Tests/Editor/JActionTests.cs
+++ b/UnityProject/Packages/com.jasonxudeveloper.jengine.util/Tests/Editor/JActionTests.cs
@@ -473,7 +473,7 @@ namespace JEngine.Util.Tests
         {
             int counter = 0;
 
-            var action = JAction.Create()
+            using var action = JAction.Create()
                 .Do(() => counter++);
 
             action.Execute();
@@ -484,8 +484,6 @@ namespace JEngine.Util.Tests
                 .Execute();
 
             Assert.AreEqual(11, counter);
-
-            action.Dispose();
         }
 
         #endregion


### PR DESCRIPTION
## Summary

- Fixes [CodeQL security alert #12](https://github.com/JasonXuDeveloper/JEngine/security/code-scanning/12) (cs/dispose-not-called-on-throw)
- Changes `var action` to `using var action` to ensure disposal on exception

## Problem

The `Reset_AllowsReuse` test created a `JAction` and called `Dispose()` at the end. However, if `Execute()`, `Reset()`, or `Do()` threw an exception, the method would exit early and `Dispose()` would never be called.

## Solution

Use a `using` declaration which guarantees disposal even when exceptions occur.

## Test plan

- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)