### PR TITLE
fix(core): bump Nino to fix Dictionary serialization in HybridCLR

### DIFF
--- a/UnityProject/Packages/com.jasonxudeveloper.jengine.core/package.json
+++ b/UnityProject/Packages/com.jasonxudeveloper.jengine.core/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "com.cysharp.unitask": "2.5.10",
-    "com.jasonxudeveloper.nino": "4.0.0-preview.137",
+    "com.jasonxudeveloper.nino": "4.0.0-preview.147",
     "com.tuyoogame.yooasset": "2.3.16"
   }
 }

--- a/UnityProject/Packages/manifest.json
+++ b/UnityProject/Packages/manifest.json
@@ -3,7 +3,7 @@
     "com.code-philosophy.obfuz": "https://github.com/focus-creative-games/obfuz.git",
     "com.code-philosophy.obfuz4hybridclr": "https://github.com/focus-creative-games/obfuz4hybridclr.git",
     "com.cysharp.unitask": "2.5.10",
-    "com.jasonxudeveloper.nino": "4.0.0-preview.143",
+    "com.jasonxudeveloper.nino": "4.0.0-preview.147",
     "com.tuyoogame.yooasset": "2.3.18",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.tilemap": "1.0.0",

--- a/UnityProject/Packages/packages-lock.json
+++ b/UnityProject/Packages/packages-lock.json
@@ -33,7 +33,7 @@
       "source": "embedded",
       "dependencies": {
         "com.cysharp.unitask": "2.5.10",
-        "com.jasonxudeveloper.nino": "4.0.0-preview.137",
+        "com.jasonxudeveloper.nino": "4.0.0-preview.147",
         "com.tuyoogame.yooasset": "2.3.16"
       }
     },

--- a/UnityProject/Packages/packages-lock.json
+++ b/UnityProject/Packages/packages-lock.json
@@ -53,7 +53,7 @@
       "dependencies": {}
     },
     "com.jasonxudeveloper.nino": {
-      "version": "4.0.0-preview.143",
+      "version": "4.0.0-preview.147",
       "depth": 0,
       "source": "registry",
       "dependencies": {},


### PR DESCRIPTION
## Summary

- Bumps Nino from `4.0.0-preview.143` to `4.0.0-preview.147` which fixes `ArrayTypeMismatchException` when serializing `[NinoType]` classes containing `Dictionary` fields under HybridCLR's interpreter

## Root Cause

Nino's generated Dictionary serializer used `Unsafe.As<Dictionary, DictionaryView>` to access internal `_entries`. HybridCLR's `ldelema` instruction enforces strict runtime type checking, detecting `DictionaryView.Entry` ≠ `Dictionary.Entry` and throwing `ArrayTypeMismatchException`.

Fixes #621
Ref: JasonXuDeveloper/Nino#172

## Test plan

- [ ] Build to Android with HybridCLR hot update
- [ ] Serialize/deserialize a `[NinoType]` class with `Dictionary` fields
- [ ] Verify no `ArrayTypeMismatchException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)