### PR TITLE
docs(ui): add JTabView to plugin skill docs

### DIFF
--- a/.claude-plugin/CLAUDE.md
+++ b/.claude-plugin/CLAUDE.md
@@ -10,7 +10,7 @@ Unity framework for runtime hot updates. Unity 2022.3+, C#.
 
 ### JEngine.UI (com.jasonxudeveloper.jengine.ui)
 - **MessageBox**: Async modal dialogs with UniTask (runtime)
-- **Editor Components**: JButton, JTextField, JStack, JCard, etc. (editor)
+- **Editor Components**: JButton, JTextField, JStack, JCard, JTabView, etc. (editor)
 - **Design Tokens**: Theme-aware colors, spacing, typography
 
 ## Key Patterns

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jengine",
   "description": "AI guide for game development with JEngine Unity hot-update framework",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "author": {
     "name": "JasonXuDeveloper"
   },

--- a/.claude-plugin/skills/editor-ui/SKILL.md
+++ b/.claude-plugin/skills/editor-ui/SKILL.md
@@ -254,7 +254,7 @@ var responsiveTabs = new JTabView(maxTabsPerRow: 3)
     .AddTab("Tab 1", content1)
     .AddTab("Tab 2", content2);
 
-// Programmatic selection
+// Programmatic selection (zero-based index: 0=General, 1=Advanced, 2=Debug)
 tabs.SelectTab(2);  // Select "Debug" tab
 
 // Read state

--- a/.claude-plugin/skills/editor-ui/SKILL.md
+++ b/.claude-plugin/skills/editor-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: editor-ui
-description: JEngine Editor UI component library with theming. Triggers on: custom inspector, editor window, Unity editor UI, UIElements, VisualElement, JButton, JStack, JCard, JTextField, JDropdown, design tokens, dark theme, light theme, editor styling, themed button, form layout, progress bar, status bar, toggle button, button group
+description: JEngine Editor UI component library with theming. Triggers on: custom inspector, editor window, Unity editor UI, UIElements, VisualElement, JButton, JStack, JCard, JTextField, JDropdown, JTabView, tab view, tabbed container, design tokens, dark theme, light theme, editor styling, themed button, form layout, progress bar, status bar, toggle button, button group
 ---
 
 # JEngine Editor UI Components
@@ -241,6 +241,28 @@ bc.SetPath("New", "Path");
 bc.Clear();
 ```
 
+### JTabView - Tabbed Container
+```csharp
+// Basic tab view
+var tabs = new JTabView()
+    .AddTab("General", generalContent)
+    .AddTab("Advanced", advancedContent)
+    .AddTab("Debug", debugContent);
+
+// Responsive: max 3 tabs per row before wrapping
+var responsiveTabs = new JTabView(maxTabsPerRow: 3)
+    .AddTab("Tab 1", content1)
+    .AddTab("Tab 2", content2);
+
+// Programmatic selection
+tabs.SelectTab(2);  // Select "Debug" tab
+
+// Read state
+int selected = tabs.SelectedIndex;  // -1 if no tabs
+int count = tabs.TabCount;
+int maxPerRow = tabs.MaxTabsPerRow;
+```
+
 ## Design Tokens
 
 The `Tokens` class provides named constants that adapt to Unity's dark/light theme.
@@ -365,7 +387,7 @@ enum AlignItems { Start, Center, End, Stretch }
 
 ## Game Development Examples
 
-### Settings Panel
+### Settings Panel (with Tabs)
 ```csharp
 public class GameSettingsWindow : EditorWindow
 {
@@ -384,8 +406,8 @@ public class GameSettingsWindow : EditorWindow
         root.style.paddingBottom = Tokens.Spacing.Lg;
         root.style.paddingLeft = Tokens.Spacing.Lg;
 
-        // Graphics Section
-        var graphics = new JSection("Graphics")
+        // Graphics tab content
+        var graphics = new JStack(GapSize.MD)
             .Add(
                 new JFormField("VSync", _vsyncToggle = new JToggle(true)),
                 new JFormField("Target FPS", _fpsDropdown = new JDropdown<int>(
@@ -394,17 +416,22 @@ public class GameSettingsWindow : EditorWindow
                     formatSelectedValue: static fps => fps == -1 ? "Unlimited" : $"{fps} FPS",
                     formatListItem: static fps => fps == -1 ? "Unlimited" : $"{fps} FPS")));
 
-        // Audio Section
-        var audio = new JSection("Audio")
+        // Audio tab content
+        var audio = new JStack(GapSize.MD)
             .Add(new JFormField("Master Volume", _volumeSlider = new JProgressBar(0.8f)
                 .WithHeight(20)));
+
+        // Tabbed settings
+        var tabs = new JTabView()
+            .AddTab("Graphics", graphics)
+            .AddTab("Audio", audio);
 
         // Actions
         var actions = new JButtonGroup(
             new JButton("Apply", ApplySettings, ButtonVariant.Primary),
             new JButton("Reset", ResetSettings, ButtonVariant.Secondary));
 
-        root.Add(graphics, audio, actions);
+        root.Add(tabs, actions);
         rootVisualElement.Add(root);
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,3 +92,4 @@ Document all public APIs with XML comments.
 - [ ] Thread-safe where needed
 - [ ] Proper resource cleanup
 - [ ] Unit tests added for non-core package changes
+- [ ] Plugin skill docs updated for new/changed JEngine.Util or JEngine.UI APIs (see `.claude/rules/plugin-maintenance.md`)


### PR DESCRIPTION
## Summary
- Add JTabView API reference (constructor, `AddTab`, `SelectTab`, properties) to `.claude-plugin/skills/editor-ui/SKILL.md` with trigger keywords
- Update the Settings Panel example to demonstrate tabbed layout using `JTabView`
- Add `JTabView` to the component list in `.claude-plugin/CLAUDE.md`
- Add plugin maintenance checklist item to `CLAUDE.md` Code Review Checklist so this gap doesn't recur
- Bump plugin version `1.0.6` → `1.1.0`

## Test plan
- [ ] Verify SKILL.md frontmatter triggers match on "JTabView", "tab view", "tabbed container"
- [ ] Verify JTabView API docs match actual source (`JTabView(int maxTabsPerRow = 0)`, `AddTab`, `SelectTab`, `SelectedIndex`, `TabCount`, `MaxTabsPerRow`)
- [ ] Confirm Settings Panel example compiles conceptually (uses `JStack` for tab content, `JTabView` for tabbing)
- [ ] Confirm plugin.json version follows semver (minor bump for new API coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)