### PR TITLE
fix(core): use synchronous asset loading for AOT metadata

### DIFF
--- a/UnityProject/Packages/com.jasonxudeveloper.jengine.core/Runtime/Bootstrap.cs
+++ b/UnityProject/Packages/com.jasonxudeveloper.jengine.core/Runtime/Bootstrap.cs
@@ -155,6 +155,13 @@ namespace JEngine.Core
         private void LoadMetadataForAOTAssemblies()
         {
             var aotListHandle = YooAssets.LoadAssetSync<TextAsset>(aotDllListFilePath);
+            if (aotListHandle.Status != EOperationStatus.Succeed)
+            {
+                Debug.LogError($"Failed to load AOT DLL list: {aotListHandle.LastError}");
+                aotListHandle.Release();
+                return;
+            }
+
             TextAsset aotDataAsset = aotListHandle.GetAssetObject<TextAsset>();
             var aotDllList = NinoDeserializer.Deserialize<List<string>>(aotDataAsset.bytes);
             aotListHandle.Release();
@@ -168,6 +175,13 @@ namespace JEngine.Core
                 }
 
                 var handle = YooAssets.LoadAssetSync<TextAsset>(aotDllName);
+                if (handle.Status != EOperationStatus.Succeed)
+                {
+                    Debug.LogError($"Failed to load AOT DLL {aotDllName}: {handle.LastError}");
+                    handle.Release();
+                    continue;
+                }
+
                 byte[] dllBytes = handle.GetAssetObject<TextAsset>().bytes;
                 var err = RuntimeApi.LoadMetadataForAOTAssembly(dllBytes, HomologousImageMode.SuperSet);
                 Debug.Log($"LoadMetadataForAOTAssembly:{aotDllName}. ret:{err}");

--- a/UnityProject/Packages/com.jasonxudeveloper.jengine.core/Runtime/Bootstrap.cs
+++ b/UnityProject/Packages/com.jasonxudeveloper.jengine.core/Runtime/Bootstrap.cs
@@ -152,10 +152,9 @@ namespace JEngine.Core
             Debug.Log("SetUpDynamicSecret end");
         }
 
-        private async UniTask LoadMetadataForAOTAssemblies()
+        private void LoadMetadataForAOTAssemblies()
         {
-            var aotListHandle = YooAssets.LoadAssetAsync<TextAsset>(aotDllListFilePath);
-            await aotListHandle.Task;
+            var aotListHandle = YooAssets.LoadAssetSync<TextAsset>(aotDllListFilePath);
             TextAsset aotDataAsset = aotListHandle.GetAssetObject<TextAsset>();
             var aotDllList = NinoDeserializer.Deserialize<List<string>>(aotDataAsset.bytes);
             aotListHandle.Release();
@@ -168,8 +167,7 @@ namespace JEngine.Core
                     continue;
                 }
 
-                var handle = YooAssets.LoadAssetAsync<TextAsset>(aotDllName);
-                await handle.Task;
+                var handle = YooAssets.LoadAssetSync<TextAsset>(aotDllName);
                 byte[] dllBytes = handle.GetAssetObject<TextAsset>().bytes;
                 var err = RuntimeApi.LoadMetadataForAOTAssembly(dllBytes, HomologousImageMode.SuperSet);
                 Debug.Log($"LoadMetadataForAOTAssembly:{aotDllName}. ret:{err}");
@@ -293,7 +291,7 @@ namespace JEngine.Core
 
                     // First supplement metadata
                     updateStatusText.text = text.loadingCode;
-                    await LoadMetadataForAOTAssemblies();
+                    LoadMetadataForAOTAssemblies();
                     // Set dynamic key
                     updateStatusText.text = text.decryptingResources;
                     await SetUpDynamicSecret();


### PR DESCRIPTION
## Summary
- Replace `LoadAssetAsync` + `await` with `LoadAssetSync` in `LoadMetadataForAOTAssemblies`, eliminating N+ frames of unnecessary delay during initialization
- Change the method from `async UniTask` to `void` since no async operations remain
- Safe because this runs during bootstrap before gameplay begins

## Test plan
- [ ] Verify project compiles without errors in Unity 2022.3+
- [ ] Confirm AOT metadata loads correctly on a build with HybridCLR enabled
- [ ] Check initialization timing improvement (fewer frames spent in metadata loading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)