### PR TITLE
chore(ci): relax codecov patch check to 85% floor + informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,12 +5,23 @@ coverage:
   status:
     project:
       default:
-        target: auto
-        threshold: 1%
+        # Floor at 85% so normal drift (a few hard-to-unit-test editor paths)
+        # does not fail the check. Base project is ~95%, so there is plenty of
+        # headroom without ratcheting it tighter on every PR.
+        target: 85%
+        threshold: 2%
     patch:
       default:
-        target: auto
-        threshold: 1%
+        # Same 85% floor for added/changed lines. Editor-window callbacks
+        # (OnFocus, polling schedule) are not cleanly unit-testable, so we
+        # accept a handful of uncovered lines per PR instead of chasing
+        # auto-vs-base noise.
+        target: 85%
+        threshold: 2%
+        # Informational: show the comment (so reviewers see where coverage
+        # dropped) but never block the merge. The project check above still
+        # guards against real regressions.
+        informational: true
 
 # Fix Docker container path prefix in coverage reports
 # Unity test runner generates paths like /github/workspace/UnityProject/...


### PR DESCRIPTION
## Summary

The previous codecov config used \`target: auto\` with a 1% threshold on both \`project\` and \`patch\`. That ratchets the bar tighter each time new easily-tested code lands, and penalises PRs that touch editor-window callbacks or polling loops which are not cleanly unit-testable (e.g. \`Panel.OnFocus\`, \`schedule.Execute\` polling).

Discovered on #633 — 95.81% patch coverage was flagged as ❌ because it was below the ~95% base.

## Changes

- **Project check**: \`target: 85%\`, \`threshold: 2%\` — fixed floor instead of ratcheting off base.
- **Patch check**: \`target: 85%\`, \`threshold: 2%\`, \`informational: true\` — the comment still surfaces uncovered lines (useful for review) but never blocks merge. The project check still guards against real regressions.

## Test plan

- [ ] Open any PR; confirm codecov comment appears and patch status no longer blocks merge.
- [ ] Confirm project status still fires if total coverage drops below 83% (85 − 2).