### PR TITLE
fix(core): resolve Obfuz player-build failure when HotUpdate.Code is referenced

### DIFF
--- a/UnityProject/Assets/HotUpdate/Code/HotUpdate.Code.asmdef
+++ b/UnityProject/Assets/HotUpdate/Code/HotUpdate.Code.asmdef
@@ -18,7 +18,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
-    "autoReferenced": true,
+    "autoReferenced": false,
     "defineConstraints": [],
     "versionDefines": [],
     "noEngineReferences": false

--- a/UnityProject/Packages/com.jasonxudeveloper.jengine.core/Editor/CustomEditor/ObfuzHotUpdateSearchPathInjector.cs
+++ b/UnityProject/Packages/com.jasonxudeveloper.jengine.core/Editor/CustomEditor/ObfuzHotUpdateSearchPathInjector.cs
@@ -1,0 +1,127 @@
+// ObfuzHotUpdateSearchPathInjector.cs
+//
+//  Author:
+//        JasonXuDeveloper <jason@xgamedev.net>
+//
+//  Copyright (c) 2025 JEngine
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+using System.IO;
+using System.Linq;
+using HybridCLR.Editor;
+using Obfuz.Settings;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEngine;
+
+namespace JEngine.Core.Editor.CustomEditor
+{
+    /// <summary>
+    /// Makes the HybridCLR hot-update DLL output directory visible to Obfuz's
+    /// player-build obfuscation pass so <c>Assembly-CSharp</c>'s reference to
+    /// <c>HotUpdate.Code</c> (when present) can be resolved.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// During a Unity player build, HybridCLR's <c>FilterHotFixAssemblies</c>
+    /// strips hot-update assemblies from the player staging area (correct — they
+    /// must not ship as baked code). Obfuz's
+    /// <c>ObfuscationProcess.OnPostBuildPlayerScriptDLLs</c> then obfuscates the
+    /// remaining player DLLs and, via <c>AssemblyCache.LoadModule</c>, recursively
+    /// resolves every <c>GetAssemblyRefs()</c> entry through a flat
+    /// <c>PathAssemblyResolver</c>. If any obfuscated player assembly references
+    /// <c>HotUpdate.Code</c>, the resolver can't find it and Obfuz throws
+    /// <c>FileNotFoundException: Assembly HotUpdate.Code not found</c>.
+    /// </para>
+    /// <para>
+    /// This processor adds <c>HybridCLRData/HotUpdateDlls/&lt;target&gt;/</c> to
+    /// <c>ObfuzSettings.additionalAssemblySearchPaths</c> at the start of the
+    /// build (in-memory only — <c>Obfuz.asset</c> on disk is never modified) and
+    /// restores the original list afterwards.
+    /// </para>
+    /// </remarks>
+    internal sealed class ObfuzHotUpdateSearchPathInjector
+        : IPreprocessBuildWithReport, IPostprocessBuildWithReport
+    {
+        // Run before Obfuz's IPostBuildPlayerScriptDLLs (callbackOrder = 10000).
+        public int callbackOrder => 0;
+
+        private string[] _originalSearchPaths;
+        private bool _injected;
+
+        public void OnPreprocessBuild(BuildReport report)
+        {
+            AssemblySettings assemblySettings = ObfuzSettings.Instance.assemblySettings;
+            _originalSearchPaths = assemblySettings.additionalAssemblySearchPaths
+                                   ?? System.Array.Empty<string>();
+            _injected = true;
+
+            string hotUpdateDir =
+                SettingsUtil.GetHotUpdateDllsOutputDirByTarget(report.summary.platform);
+
+            if (string.IsNullOrEmpty(hotUpdateDir) || !Directory.Exists(hotUpdateDir))
+            {
+                Debug.LogWarning(
+                    $"[JEngine] HybridCLR hot-update directory not found: " +
+                    $"'{hotUpdateDir}'. If the player build fails with " +
+                    $"'Assembly HotUpdate.Code not found' during Obfuz obfuscation, " +
+                    $"run 'Build Main Package (code)' from the JEngine Panel first " +
+                    $"so HybridCLR compiles the hot-update assemblies for this target.");
+                return;
+            }
+
+            if (_originalSearchPaths.Any(p => AreSamePath(p, hotUpdateDir)))
+            {
+                return;
+            }
+
+            assemblySettings.additionalAssemblySearchPaths =
+                _originalSearchPaths.Concat(new[] { hotUpdateDir }).ToArray();
+
+            Debug.Log(
+                $"[JEngine] Injected HybridCLR hot-update dir into Obfuz search " +
+                $"paths for this build: {hotUpdateDir}");
+        }
+
+        public void OnPostprocessBuild(BuildReport report)
+        {
+            if (!_injected) return;
+
+            ObfuzSettings.Instance.assemblySettings.additionalAssemblySearchPaths =
+                _originalSearchPaths;
+            _originalSearchPaths = null;
+            _injected = false;
+        }
+
+        private static bool AreSamePath(string a, string b)
+        {
+            if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b)) return false;
+            try
+            {
+                return Path.GetFullPath(a).TrimEnd(Path.DirectorySeparatorChar)
+                    == Path.GetFullPath(b).TrimEnd(Path.DirectorySeparatorChar);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/UnityProject/Packages/com.jasonxudeveloper.jengine.core/Editor/CustomEditor/ObfuzHotUpdateSearchPathInjector.cs.meta
+++ b/UnityProject/Packages/com.jasonxudeveloper.jengine.core/Editor/CustomEditor/ObfuzHotUpdateSearchPathInjector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 772fbac4208e84eb4bc1d0707ad26847
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Packages/com.jasonxudeveloper.jengine.ui/Tests/Editor/Utilities/EditorUtilsTests.cs.meta
+++ b/UnityProject/Packages/com.jasonxudeveloper.jengine.ui/Tests/Editor/Utilities/EditorUtilsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16dcf5d383a9a4aa5962ab1505770150
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

- Fixes `FileNotFoundException: Assembly HotUpdate.Code not found` from Obfuz during Unity player build for users who have a compile-time reference to `HotUpdate.Code` anywhere in Assembly-CSharp.
- Two-part fix: flip `autoReferenced` to `false` on the template's `HotUpdate.Code.asmdef` (removes the trigger by construction), plus an `IPreprocessBuildWithReport` / `IPostprocessBuildWithReport` that injects `HybridCLRData/HotUpdateDlls/<target>/` into `ObfuzSettings.additionalAssemblySearchPaths` only during the build (defensive catch-all for users who deviate from the template).
- Does NOT modify `Obfuz.asset` on disk; mutation is in-memory and reverted post-build.

## Why not just disable Obfuz

The workaround circulating in reports ("set Obfuz off") silently disables the entire player-DLL obfuscation stage - shipping `Assembly-CSharp`, `JEngine.Core`, and `Obfuz.Generated` unobfuscated. That trades a real security feature for a clean build log. This PR keeps obfuscation on.

## Root cause

`ObfuscationProcess.OnPostBuildPlayerScriptDLLs` (`com.code-philosophy.obfuz/Editor/Unity/ObfuscationProcess.cs`, callbackOrder 10000) obfuscates the player's managed DLLs. It builds an `Obfuscator` whose `AssemblyCache.LoadModule` (`Editor/Utils/AssemblyCache.cs:75-97`) **recursively** resolves every `GetAssemblyRefs()` entry through a flat `PathAssemblyResolver`.

- HybridCLR's `FilterHotFixAssemblies` (`IFilterBuildAssemblies`) correctly strips `HotUpdate.Code` from the player staging area so it doesn't ship baked in.
- But `HotUpdate.Code.dll` still exists in `HybridCLRData/HotUpdateDlls/<target>/` from the prior code-build step - and Obfuz's resolver doesn't look there.
- Combined with `"autoReferenced": true` on `HotUpdate.Code.asmdef`, any Assembly-CSharp source that uses a `HotUpdate.Code.*` type embeds a real assembly ref into Assembly-CSharp. Obfuz then tries to load it during recursion and throws.

The `assembly: HotUpdate.Code not found! ignore.` line is a red herring - it's `TryLoadModule` returning null on the first pass. The actual throw comes from the subsequent strict `LoadModule` call in `AssemblyCache.LoadModule`'s `foreach (var refAsm in mod.GetAssemblyRefs())` recursion.

## Changes

1. **`UnityProject/Assets/HotUpdate/Code/HotUpdate.Code.asmdef`** - `"autoReferenced": true` -> `false`. Hot-update assemblies should not be compile-referenced by Unity's predefined assemblies; main code loads them at runtime. Safe for the template: `PromptInitializer.cs` references only `JEngine.Core`/`JEngine.UI`, and HybridCLR's own `AOTGenericReferences.cs` emits all `HotUpdate.Code.*` entries as `//` comments (`GenericReferenceWriter.cs:72-127`).
2. **`UnityProject/Packages/com.jasonxudeveloper.jengine.core/Editor/CustomEditor/ObfuzHotUpdateSearchPathInjector.cs`** (new) - single class implementing both build-report hooks. Snapshots `ObfuzSettings.additionalAssemblySearchPaths` pre-build, appends `SettingsUtil.GetHotUpdateDllsOutputDirByTarget(target)` if present (warning log if missing, directing users to run the JEngine code-build step first), restores the original list post-build.

Rebase-merge friendly: each commit is self-contained.

## Test plan

- [ ] **Reproduce on current master** - revert the asmdef flip, add `Assets/Scripts/Ref.cs` doing `public static System.Type t = typeof(HotUpdate.Code.EntryPoint);`, delete the injector, switch to Android, run Build Main Package (code), then `File -> Build Settings -> Build`. Expect `FileNotFoundException: Assembly HotUpdate.Code not found` and `Obfuscation failed.`
- [ ] **Injector-only** - keep `autoReferenced: true` and the throwaway ref file, restore the injector. Android build succeeds; console shows `[JEngine] Injected HybridCLR hot-update dir into Obfuz search paths for this build: HybridCLRData/HotUpdateDlls/Android`. `Library/Obfuz/Android/ObfuscatedAssemblies/Assembly-CSharp.dll` exists and is larger than the staging copy.
- [ ] **Asmdef-only** - flip to `autoReferenced: false`, remove the throwaway ref file, remove the injector. Android build succeeds with no injection log (Assembly-CSharp no longer references `HotUpdate.Code`).
- [ ] **Both together (this PR)** - default setup, Android build succeeds. No injection log on a clean template because there's no ref; if a user has one, the injector catches it.
- [ ] **Missing hot-update dir** - delete `HybridCLRData/HotUpdateDlls/Android/` and build. Injector logs a clear warning naming the path and advising to run Build Main Package (code) first.
- [ ] **Other target** - repeat on `StandaloneOSX`, confirm the per-target path is used.
- [ ] **Obfuz disabled** - set `ObfuzSettings.buildPipelineSettings.enable = 0`, build succeeds (injector runs harmlessly, Obfuz exits early).
- [ ] **Disk state untouched** - confirm `ProjectSettings/Obfuz.asset` `additionalAssemblySearchPaths` is unchanged on disk after any build.
- [ ] **Built player does not ship HotUpdate.Code.dll** - inspect the final APK: `HotUpdate.Code.dll.bytes` present under streaming assets, no raw `HotUpdate.Code.dll` assembly.

No unit tests: core package convention is no editor tests (consistent with existing `BuildManager.cs`), and the hook's inputs (`BuildReport`, `ObfuzSettings.Instance`, `SettingsUtil` static) aren't meaningfully mockable without a refactor that would add more surface area than the 10 lines of dedup-and-mutate logic being tested.